### PR TITLE
Updating rasterio affine call

### DIFF
--- a/source/lessons/L6/zonal-statistics.rst
+++ b/source/lessons/L6/zonal-statistics.rst
@@ -62,7 +62,7 @@ Quite often you have a situtation when you want to summarize raster datasets bas
 .. ipython:: python
 
     array = dem.read(1)
-    affine = dem.affine
+    affine = dem.transform
 
 - Now we can calculate the zonal statistics by using the function ``zonal_stats``.
 


### PR DESCRIPTION
The latest version of rasterio (v1.0.21) has removed the call `.affine`. To get the affine object from the `rasterio.io.DatasetReader` object you must now call `.transform`.