### PR TITLE
Update deprecated osmnx method to get buildings

### DIFF
--- a/source/lessons/L3/retrieve-osm-data.rst
+++ b/source/lessons/L3/retrieve-osm-data.rst
@@ -70,7 +70,7 @@ Great! Now we can see that our graph contains the nodes (blue circles) and the e
 
 It is also possible to retrieve other types of OSM data features with osmnx.
 
-- Let's download the buildings with ``footprints_from_place()`` function from OSM's `footprints` module and plot them on top of our street network in Kamppi. Let's also plot the Polygon that represents the area of Kamppi,
+- Let's download the buildings with ``footprints_from_place()`` function from OSM's ``footprints`` module and plot them on top of our street network in Kamppi. Let's also plot the Polygon that represents the area of Kamppi,
 Helsinki that can be retrieved with ``gdf_from_place`` function.
 
 .. ipython:: python

--- a/source/lessons/L3/retrieve-osm-data.rst
+++ b/source/lessons/L3/retrieve-osm-data.rst
@@ -70,13 +70,13 @@ Great! Now we can see that our graph contains the nodes (blue circles) and the e
 
 It is also possible to retrieve other types of OSM data features with osmnx.
 
-- Let's download the buildings with ``buildings_from_place()`` function and plot them on top of our street network in Kamppi. Let's also plot the Polygon that represents the area of Kamppi,
+- Let's download the buildings with ``footprints_from_place()`` function from OSM's `footprints` module and plot them on top of our street network in Kamppi. Let's also plot the Polygon that represents the area of Kamppi,
 Helsinki that can be retrieved with ``gdf_from_place`` function.
 
 .. ipython:: python
 
     area = ox.gdf_from_place(place_name)
-    buildings = ox.buildings_from_place(place_name)
+    buildings = ox.footprints.footprints_from_place(place_name, footprint_type='building')
     type(area)
     type(buildings)
 


### PR DESCRIPTION
The ``buildings_from_place()`` method was removed as of [0.10 (2019-05-08)](https://github.com/gboeing/osmnx/blob/master/CHANGELOG.md#010-2019-05-08) and calling it results in an error. Replaced it with the correct ``footprints_from_place()`` method. 